### PR TITLE
Project specific include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ $ apm install linter-clang
 - C linter, select C Grammar
 - C++ linter, select C++ Grammar
 
+### Project-specific include paths
+If your project has some extra include directories, put them in a file called ".linter-clang-includes" and list them line by line or seperated by spaces.
+The linter will open the file in those directories and use the specified paths when linting in your project.
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,7 +1,7 @@
 module.exports =
   configDefaults:
     clangExecutablePath: null
-    clangIncludePath: '.'
+    clangIncludePaths: '.'
     clangSuppressWarnings: false
     clangDefaultCFlags: '-Wall'
     clangDefaultCppFlags: '-Wall'

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -2,6 +2,7 @@
 linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 path = require 'path'
+fs = require 'fs'
 # ClangFlags = require 'clang-flags'
 
 class LinterClang extends Linter
@@ -35,8 +36,16 @@ class LinterClang extends Linter
     else
       @cmd += ' ' + atom.config.get 'linter-clang.clangDefaultCFlags'
 
-    includepath = atom.config.get 'linter-clang.clangIncludePath'
-    split = includepath.split " "
+    includepaths = atom.config.get 'linter-clang.clangIncludePaths'
+
+    # read other include paths from file in project
+    filename = atom.project.getPaths()[0] + '/.linter-clang-includes'
+    if fs.existsSync filename
+        file = fs.readFileSync filename, 'utf8'
+        includepaths = "#{includepaths} #{file.replace('\n', ' ')}"
+
+    split = includepaths.split " "
+
     # concat includepath
     for custompath in split
       if custompath.length > 0


### PR DESCRIPTION
-> See my issue

Read extra include paths from '.linter-clang-includes' in the project dir, so it does not need to be included globally. And: renamed clangIncludePath to clangIncludePaths since they may be more than one (more clear for the user)
