### PR TITLE
Handle new scope name for C++

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -8,7 +8,7 @@ fs = require 'fs'
 class LinterClang extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.c++', 'source.c']
+  @syntax: ['source.c++', 'source.cpp', 'source.c']
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope names for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.