### PR TITLE
Add the Ability to Lint Objective-C and Objective-C++

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,7 +1,6 @@
 module.exports =
   configDefaults:
     clangCommand: 'clang'
-    clangPlusPlusCommand: 'clang++'
     clangExecutablePath: null
     clangIncludePaths: '.'
     clangSuppressWarnings: false

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -8,7 +8,7 @@ fs = require 'fs'
 class LinterClang extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.c++', 'source.c']
+  @syntax: ['source.c++', 'source.cpp', 'source.c']
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -8,7 +8,8 @@ fs = require 'fs'
 class LinterClang extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.c++', 'source.cpp', 'source.c']
+  @syntax: ['source.c++', 'source.cpp', 'source.c', 'source.objc++',
+  'source.objcpp', 'source.objc']
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.


### PR DESCRIPTION
Simplified the linting code so that all language use the same clang command, but different options per language.

The C++ related code respects the recent C++ language identifier change in Atom.

Fixes #17 
Fixes #18 