### PR TITLE
Fix/relative include

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -7,6 +7,7 @@ module.exports =
     clangDefaultCFlags: '-Wall'
     clangDefaultCppFlags: '-Wall'
     clangErrorLimit: 0
+    clangCompleteFile: false
 
   activate: ->
     console.log 'activate linter-clang'

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -44,7 +44,6 @@ class LinterClang extends Linter
 
     @cmd += ' -ferror-limit=' + atom.config.get 'linter-clang.clangErrorLimit'
 
-    console.log atom.config.get 'linter-clang.clangCompleteFile'
     if atom.config.get 'linter-clang.clangCompleteFile'
       @cmd += ' ' + ClangFlags.getClangFlags(@editor.getPath()).join ' '
 

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -47,6 +47,8 @@ class LinterClang extends Linter
     if atom.config.get 'linter-clang.clangCompleteFile'
       @cmd += ' ' + ClangFlags.getClangFlags(@editor.getPath()).join ' '
 
+    @cmd += ' -I' + @editor.getPath().replace(/(.*)\/.*/, '$1')
+
     includepaths = atom.config.get 'linter-clang.clangIncludePaths'
 
     # read other include paths from file in project
@@ -61,7 +63,7 @@ class LinterClang extends Linter
     # concat includepath
     for custompath in split
       if custompath.length > 0
-        @cmd = "#{@cmd} -I #{custompath}"
+        @cmd = "#{@cmd} -I#{custompath}"
         # if the path is relative, resolve it
         # TODO: if path contain blank space!!!
         # custompathResolved = path.resolve(atom.project.getPaths()[0], custompath)

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -3,7 +3,7 @@ linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 path = require 'path'
 fs = require 'fs'
-# ClangFlags = require 'clang-flags'
+ClangFlags = require 'clang-flags'
 
 class LinterClang extends Linter
   # The syntax that the linter handles. May be a string or
@@ -43,6 +43,10 @@ class LinterClang extends Linter
       @cmd += ' ' + atom.config.get 'linter-clang.clangDefaultCFlags'
 
     @cmd += ' -ferror-limit=' + atom.config.get 'linter-clang.clangErrorLimit'
+
+    console.log atom.config.get 'linter-clang.clangCompleteFile'
+    if atom.config.get 'linter-clang.clangCompleteFile'
+      @cmd += ' ' + ClangFlags.getClangFlags(@editor.getPath()).join ' '
 
     includepaths = atom.config.get 'linter-clang.clangIncludePaths'
 

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+      "clang-flags": "git://github.com/wanderer2/clang-flags.git"
+  }
 }


### PR DESCRIPTION
Hi,

when a cpp file uses the "include" directive for a relative hpp, linter-clang breaks because it runs clang on a tmp copy of the actual cpp file. I fixed this by automagically adding a -I to the actual edited file path.