### PR TITLE
Fixed issue #30

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -91,7 +91,7 @@ class LinterClang extends Linter
     # add includepaths
     for custompath in includepathsSplit
       if custompath.length > 0
-        custompathResolved = path.resolve(atom.project.getPaths()[0], custompath)
+        custompathResolved = path.resolve(@cwd, custompath)
         args.push '-I'
         args.push custompathResolved
 


### PR DESCRIPTION
The custom path now uses the current file path instead of the project root path as origin.

Fix issue https://github.com/AtomLinter/linter-clang/issues/30