### PR TITLE
Macros & Recursive .linter-clang-includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ $ apm install linter-clang
 - C linter, select C Grammar
 - C++ linter, select C++ Grammar
 
+### Project-specific include paths
+If your project has some extra include directories, put them in a file called ".linter-clang-includes" and list them line by line or seperated by spaces.
+The linter will open the file in those directories and use the specified paths when linting in your project.
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,7 +1,7 @@
 module.exports =
   configDefaults:
     clangExecutablePath: null
-    clangIncludePath: '.'
+    clangIncludePaths: '.'
     clangSuppressWarnings: false
     clangDefaultCFlags: '-Wall'
     clangDefaultCppFlags: '-Wall'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -5,6 +5,7 @@ module.exports =
     clangSuppressWarnings: false
     clangDefaultCFlags: '-Wall'
     clangDefaultCppFlags: '-Wall'
+    clangErrorLimit: 0
 
   activate: ->
     console.log 'activate linter-clang'

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -42,7 +42,16 @@ class LinterClang extends Linter
         file = file.replace(/(\r\n|\n|\r)/gm, ' ')
         includepaths = "#{includepaths} #{file}"
 
-    split = includepaths.split " "
+    # split the include paths, taking care of quotes
+    regex = /[^\s"]+|"([^"]*)"/gi
+    split = []
+
+    loop
+        match = regex.exec includepaths
+        if match
+            split.push(if match[1] then match[1] else match[0])
+        else
+            break
 
     # concat includepath
     for custompath in split

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -31,6 +31,8 @@ class LinterClang extends Linter
     else
       @cmd += ' ' + atom.config.get 'linter-clang.clangDefaultCFlags'
 
+    @cmd += ' -ferror-limit=' + atom.config.get 'linter-clang.clangErrorLimit'
+
     includepaths = atom.config.get 'linter-clang.clangIncludePaths'
 
     # read other include paths from file in project
@@ -81,6 +83,9 @@ class LinterClang extends Linter
         console.warn 'stderr', output
       if @errorStream == 'stderr'
         @processMessage(output, callback)
+
+    if atom.inDevMode()
+      console.log "command = #{command}, args = #{args}, options = #{options}"
 
     new Process({command, args, options, stdout, stderr})
     # restore cmd

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -41,7 +41,7 @@ class LinterClang extends Linter
     includepaths = atom.config.get 'linter-clang.clangIncludePaths'
 
     # read other include paths from file in project
-    filename = path.resolve(atom.project.getPaths()[0], '.linter-clang-includes')
+    filename = path.resolve(@cwd, '.linter-clang-includes')
     if fs.existsSync filename
         file = fs.readFileSync filename, 'utf8'
         file = file.replace(/(\r\n|\n|\r)/gm, ' ')
@@ -61,8 +61,13 @@ class LinterClang extends Linter
     # add includepaths
     for custompath in includepathsSplit
       if custompath.length > 0
+        # expand macro: directory of file being linted
+        custompath = custompath.replace '%d', path.dirname @editor.getPath
+        # expand macro: working directory
+        custompath = custompath.replace '%w', @cwd
+        custompath = curstompath.replace '%%', '%'
         # if the path is relative, resolve it
-        custompathResolved = path.resolve(atom.project.getPaths()[0], custompath)
+        custompathResolved = path.resolve(@cwd, custompath)
         args.push '-I'
         args.push custompathResolved
 

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -58,7 +58,7 @@ class LinterClang extends Linter
     # add file to regex to filter output to this file,
     # need to change filename a bit to fit into regex
     @regex = filePath.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") +
-        ':(?<line>\\d+):.+: .*((?<error>error)|(?<warning>warning)): (?<message>.*)'
+        ':(?<line>\\d+):(?<col>\\d+): .*((?<error>error)|(?<warning>warning)): (?<message>.*)'
 
     if atom.inDevMode()
       console.log 'is node executable: ' + @isNodeExecutable

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -2,6 +2,7 @@
 linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 path = require 'path'
+fs = require 'fs'
 # ClangFlags = require 'clang-flags'
 
 class LinterClang extends Linter
@@ -35,8 +36,16 @@ class LinterClang extends Linter
     else
       @cmd += ' ' + atom.config.get 'linter-clang.clangDefaultCFlags'
 
-    includepath = atom.config.get 'linter-clang.clangIncludePath'
-    split = includepath.split " "
+    includepaths = atom.config.get 'linter-clang.clangIncludePaths'
+
+    # read other include paths from file in project
+    filename = atom.project.getPaths()[0] + '/.linter-clang-includes'
+    if fs.existsSync filename
+        file = fs.readFileSync filename, 'utf8'
+        includepaths = "#{includepaths} #{file.replace('\n', ' ')}"
+
+    split = includepaths.split " "
+
     # concat includepath
     for custompath in split
       if custompath.length > 0

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -39,17 +39,20 @@ class LinterClang extends Linter
     includepaths = atom.config.get 'linter-clang.clangIncludePaths'
 
     # read other include paths from file in project
-    filename = atom.project.getPaths()[0] + '/.linter-clang-includes'
+    filename = path.resolve(atom.project.getPaths()[0], '.linter-clang-includes')
     if fs.existsSync filename
         file = fs.readFileSync filename, 'utf8'
-        includepaths = "#{includepaths} #{file.replace('\n', ' ')}"
+        file = file.replace(/(\r\n|\n|\r)/gm, ' ')
+        includepaths = "#{includepaths} #{file}"
 
     split = includepaths.split " "
 
     # concat includepath
     for custompath in split
       if custompath.length > 0
-        @cmd = "#{@cmd} -I #{custompath}"
+        # if the path is relative, resolve it
+        custompathResolved = path.resolve(atom.project.getPaths()[0], custompath)
+        @cmd = "#{@cmd} -I #{custompathResolved}"
     if atom.config.get 'linter-clang.clangSuppressWarnings'
       @cmd = "#{@cmd} -w"
     # build the command with arguments to lint the file


### PR DESCRIPTION
Commits: ab01ce5 and 78868f7

Fixes #30 , better than PR #31 , may also fix #29 (did not test).
Allow macros in .linter-clang-includes: %d for the directory of file being linted, %w for the working [project] directory, %% for %.
Search for .linter-clang-includes recursively, include paths specified in .linter-clang-includes in a subdirectory are then relative to the subdirectory.
Also, the include paths given in the options are now relative to the file being linted as it was before.