### PR TITLE
Fix: Don't crash on file I/O errors

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -88,10 +88,18 @@ class LinterClang extends Linter
 
     # this function searches a directory for include path files
     searchDirectory = (base) ->
-      list = fs.readdirSync base
+      try
+        list = fs.readdirSync base
+      catch err
+        return
+        
       for filename in list
         filenameResolved = path.resolve(base, filename)
-        stat = fs.statSync filenameResolved
+        try
+          stat = fs.statSync filenameResolved
+        catch err
+          continue
+
         if stat.isDirectory()
           searchDirectory filenameResolved
         if stat.isFile() and filename is '.linter-clang-includes'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Lint C, C++, Obj-C, Obj-C++ on the fly using clang",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "Lint C, C++, Obj-C, Obj-C++ on the fly using clang",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should fix #44  #42 
For example: if there is a broken link in your project, the linter tried to open it which made it crash. Dats no good.