### PR TITLE
Remove clang-flags dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to clang. It will be used with files that have the "C++", "C", "Objective-C" and "Objective-C++" syntax.
 
-## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
-
 ### Plugin installation
 Press ctrl and ',' or cmd and ',' , click on 'Packages', search 'linter clang', or:
 ```
@@ -17,9 +14,21 @@ The linter will open the file and use the specified paths when linting in your p
 
 You can put your ".linter-clang-includes" files in subdirectories, too, the linter will find them and include the paths relative to the file they are specified in.
 
-### Macros
+## Project-specific compiler flags
+If your project has some extra compiler flags, put them in a file called ".linter-clang-flags" and list all flags.
+The linter will open the file and use the specified flags when linting in your project.
+You can put your flag file in subdirectories, too, however, no resolving of paths will take place.
+For that, you can use macros (see below).
 
-The linter will expand the following macros in your ".linter-clang-includes" files:
+Note: Whenever there is a space in the flag file it will separate the strings before and after
+when passing them as arguments to the compiler (like in the command line).
+If you have a filename with a space, put it into quotes. Everything between quotes won't
+be separated. The quotes will be removed after parsing.
+Using quotes is therefore not supported yet (TODO: let the user put a backslash to escape the quote).
+
+## Macros
+
+The linter will expand the following macros in your ".linter-clang-includes" and ".linter-clang-flags" files:
  * `%d` -> the directory of the file being linted
  * `%p` -> the project path
  * `%%` -> `%`

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -8,8 +8,7 @@ module.exports =
     clangDefaultObjCFlags: ' '
     clangDefaultObjCppFlags: ' '
     clangErrorLimit: 0
-    clangCompleteFile: false
     verboseDebug: false
 
   activate: ->
-    console.log 'activate linter-clang'
+    console.log 'activate linter-clang' if atom.inDevMode()

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -52,32 +52,30 @@ class LinterClang extends Linter
     args.push '-fexceptions'
     args.push "-x#{@language}"
 
-    flagSplit = splitSpaceString switch @editor.getGrammar().name
+    defaultFlags = splitSpaceString switch @editor.getGrammar().name
         when 'C++'           then atom.config.get 'linter-clang.clangDefaultCppFlags'
         when 'Objective-C++' then atom.config.get 'linter-clang.clangDefaultObjCppFlags'
         when 'C'             then atom.config.get 'linter-clang.clangDefaultCFlags'
         when 'Objective-C'   then atom.config.get 'linter-clang.clangDefaultObjCFlags'
 
-    for customflag in flagSplit
-      if customflag.length > 0
-        args.push customflag
+    args.push defaultFlags
 
     args.push "-ferror-limit=#{atom.config.get 'linter-clang.clangErrorLimit'}"
     args.push '-w' if atom.config.get 'linter-clang.clangSuppressWarnings'
     args.push '--verbose' if verbose
 
-    expandMacros = (stringToExpand) ->
+    expandMacros = (stringToExpand) =>
       stringToExpand = stringToExpand.replace '%d', @cwd
       stringToExpand = stringToExpand.replace '%p', projectPath
       stringToExpand = stringToExpand.replace '%%', '%'
       return stringToExpand
 
-    includePaths = (base, ipathArray) ->
+    includePaths = (base, ipathArray) =>
       for ipath in ipathArray
-        if ipath.length > 0
+        if ipath
           pathExpanded = expandMacros(ipath)
           pathResolved = path.resolve(base, pathExpanded)
-          console.log "linter-clang: including #{ipath}, which expanded to #{pathResolved}" if atom.inDevMode() and verbose
+          console.log "linter-clang: including #{ipath}, which expanded to #{pathResolved}" if atom.inDevMode()
           args.push "-I#{pathResolved}"
 
     pathArray =
@@ -86,7 +84,7 @@ class LinterClang extends Linter
     includePaths @cwd, pathArray
 
     # this function searches a directory for include path files
-    searchDirectory = (base) ->
+    searchDirectory = (base) =>
       try
         list = fs.readdirSync base
       catch err
@@ -102,7 +100,7 @@ class LinterClang extends Linter
         if stat.isDirectory()
           searchDirectory filenameResolved
         if stat.isFile() and filename is '.linter-clang-includes'
-          console.log "linter-clang: found #{filenameResolved}" if atom.inDevMode() and verbose
+          console.log "linter-clang: found #{filenameResolved}" if atom.inDevMode()
           content = fs.readFileSync filenameResolved, 'utf8'
           ###
             we have to parse it to enable using quotes and space.
@@ -118,17 +116,23 @@ class LinterClang extends Linter
              instead of
                content = ['path/to/bla', 'path/two/bla', 'with', 'spaces'] # WRONG!!!
           ###
-          content = "\"" + ((content.split "\n").join "\" \"") + "\""
+          # only use line which contain stuff
+          contentLines = (line for line in content.split "\n" when line)
+          console.log "TYPEOF #{typeof contentLines}"
+          # Glue them together using quotes
+          content = "\"" + (contentLines.join "\" \"") + "\""
           contentSplit = splitSpaceString content
           # dont give base as base parameter but the path of the resolved filename!!!
           # so that all paths inside .linter-clang-includes will be relative to the file, not the project path!
           includePaths (path.dirname filenameResolved), contentSplit
         if stat.isFile() and filename is '.linter-clang-flags'
-          console.log "linter-clang: found #{filenameResolved}" if atom.inDevMode() and verbose
+          console.log "linter-clang: found #{filenameResolved}" if atom.inDevMode()
           content = fs.readFileSync filenameResolved, 'utf8'
           content = (content.split "\n").join " "
           contentSplit = splitSpaceString content
-          args.push expandMacros(contentSplit)
+          contentExpanded = expandMacros flag for flag in contentSplit
+          console.log "linter-clang: add flags: #{contentExpanded}" if atom.inDevMode()
+          args.push contentExpanded
 
     searchDirectory projectPath
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "clang-flags": "git://github.com/wanderer2/clang-flags.git",
     "Linter": "git://github.com/AtomLinter/Linter.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "Lint C, C++, Obj-C, Obj-C++ on the fly using clang",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The dependency to clang-flags causes several problems (and might cause problems in the future). To keep all in one place and maintainable, I removed the clang-flags dependency and implemented on my own (which was not much, really). This way we don't depend on external bugs or other problems. (Also 
Also updated Readme (We dont need to install `Linter` manually now).