### PR TITLE
Display underlines for all errors

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -15,6 +15,8 @@ class LinterClang extends Linter
 
   @cmd: ''
 
+  linterName: 'clang'
+
   errorStream: 'stderr'
 
   lintFile: (filePath, callback) ->

--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -158,22 +158,30 @@ class LinterClang extends Linter
     # options for BufferedProcess, same syntax with child_process.spawn
     options = {cwd: @cwd}
 
+    result = []
+
+    aggregate = (messages) ->
+      result = result.concat messages
+
     stdout = (output) =>
       if atom.inDevMode()
         console.log 'clang: stdout', output
       if @errorStream == 'stdout'
-        @processMessage(output, callback)
+        @processMessage(output, aggregate)
 
     stderr = (output) =>
       if atom.inDevMode()
         console.warn 'clang: stderr', output
       if @errorStream == 'stderr'
-        @processMessage(output, callback)
+        @processMessage(output, aggregate)
 
     if atom.inDevMode()
       console.log "linter-clang: command = #{command}, args = #{args}, options = #{options}"
 
-    new Process({command, args, options, stdout, stderr})
+    exit = () ->
+      callback result
+
+    new Process({command, args, options, stdout, stderr, exit})
 
   constructor: (editor) ->
     @editor = editor

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "linter-clang",
   "linter-package": true,
-  "activationCommands": [],
   "main": "./lib/init",
   "version": "2.25.1",
   "description": "Lint C, C++, Obj-C, Obj-C++ on the fly using clang",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-clang",
   "linter-package": true,
   "main": "./lib/init",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "Lint C, C++, Obj-C, Obj-C++ on the fly using clang",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Often only the first message is underlined in the editor; other messages are shown when the cursor is on their line, but no visual clue is available.
To solve this, all messages have to be aggregated in a single array and the linter callback passed to `lintFile` must be called only once.