### PR TITLE
Use ALL flags found in .linter-clang-flags

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -132,8 +132,8 @@ class LinterClang extends Linter
           content = fs.readFileSync filenameResolved, 'utf8'
           content = (content.split "\n").join " "
           contentSplit = splitSpaceString content
-          contentExpanded = expandMacros flag for flag in contentSplit
-          args.push contentExpanded
+          contentExpanded = (expandMacros flag for flag in contentSplit)
+          args.push contentExpanded...
 
     searchDirectory projectPath
 


### PR DESCRIPTION
Until now only the last flag specified in `.linter-clang-flags` was used. This PR fixes that.