### PR TITLE
Remove regex cache

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -142,6 +142,8 @@ class LinterClang extends Linter
     # Add file path as last argument
     args.push filePath
 
+    # Remove the cached regex added in AtomLinter/Linter#693
+    delete @MessageRegexp
     # add file to regex to filter output to this file,
     # need to change filename a bit to fit into regex
     @regex = filePath.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") +


### PR DESCRIPTION
https://github.com/AtomLinter/Linter/pull/693 updated `lib/linter.coffee` to cache `@regex` so it doesn't have to parse it on every run. This breaks `linter-clang`