### PR TITLE
Add support for .clang_complete files.

### DIFF
--- a/lib/linter-clang.coffee
+++ b/lib/linter-clang.coffee
@@ -3,6 +3,7 @@ linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 path = require 'path'
 fs = require 'fs'
+ClangFlags = require 'clang-flags'
 
 class LinterClang extends Linter
   # The syntax that the linter handles. May be a string or
@@ -138,6 +139,14 @@ class LinterClang extends Linter
           args.push contentExpanded...
 
     searchDirectory projectPath
+
+    try
+      clangflags = ClangFlags.getClangFlags(@cwd)
+      console.log "linter-clang: found .clang_complete file" if atom.inDevMode()
+      console.log clangflags if atom.inDevMode() and verbose
+      args = args.concat clangflags if clangflags
+    catch error
+      console.log "linter-clang: " + error if atom.inDevMode()
 
     # Add file path as last argument
     args.push filePath

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
-  }
+  },
+  "dependencies": {
+    "clang-flags": "0.2.2"
+  },
 }


### PR DESCRIPTION
.clang_complete files are used by other clang-based software including the autocomplete-clang Atom plugin (https://github.com/yasuyuky/autocomplete-clang) or the famous Vim clang_complete plugin (https://github.com/Rip-Rip/clang_complete).

This PR adds support for .clang_complete files using the clang-flags npm module.

This way, one can easily use existing .clang_complete files with linter-clang instead of having to create .linter-clang-flags files.