### PR TITLE
Add support for .clang_complete files.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -67,6 +67,7 @@ export default {
 
   provideLinter: () => {
     const helpers = require("atom-linter");
+    const clangFlags = require("clang-flags");
     const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>.+): (?<message>.*)";
     return {
       grammarScopes: ["source.c", "source.cpp", "source.objc", "source.objcpp"],
@@ -113,6 +114,18 @@ export default {
         atom.config.get("linter-clang.clangIncludePaths").forEach((path) =>
           args.push(`-I${path}`)
         );
+
+        try {
+          flags = clangFlags.getClangFlags(activeEditor.getPath());
+          if(flags) {
+            args.push.apply(args, flags);
+          }
+        }
+        catch (error) {
+          if(atom.config.get("linter-clang.verboseDebug")) {
+            console.log(error);
+          }
+        }
 
         // The file is added to the arguments last.
         args.push(file);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^2.0.5"
+    "atom-linter": "^2.0.5",
+    "clang-flags": "^0.2.2"
   },
   "devDependencies": {
     "eslint": "latest"


### PR DESCRIPTION
.clang_complete files are used by other clang-based software including the autocomplete-clang Atom plugin (https://github.com/yasuyuky/autocomplete-clang) or the famous Vim clang_complete plugin (https://github.com/Rip-Rip/clang_complete).

This PR adds support for .clang_complete files using the clang-flags npm module.

This way, one can easily use existing .clang_complete files with linter-clang instead of having to create .linter-clang-flags files.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-clang/99)
<!-- Reviewable:end -->
