### PR TITLE
Split the per-language default flags

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -85,22 +85,22 @@ export default {
         if(activeEditor.getGrammar().name === "C++") {
           //const language = "c++";
           args.push("-xc++");
-          args.push(atom.config.get("linter-clang.clangDefaultCppFlags"));
+          args.push(...atom.config.get("linter-clang.clangDefaultCppFlags").split(/\s+/));
         }
         if(activeEditor.getGrammar().name === "Objective-C++") {
           //const language = "objective-c++";
           args.push("-xobjective-c++");
-          args.push(atom.config.get("linter-clang.clangDefaultObjCppFlags"));
+          args.push(...atom.config.get("linter-clang.clangDefaultObjCppFlags").split(/\s+/));
         }
         if(activeEditor.getGrammar().name === "C") {
           //const language = "c";
           args.push("-xc");
-          args.push(atom.config.get("linter-clang.clangDefaultCFlags"));
+          args.push(...atom.config.get("linter-clang.clangDefaultCFlags").split(/\s+/));
         }
         if(activeEditor.getGrammar().name === "Objective-C") {
           //const language = "objective-c";
           args.push("-xobjective-c");
-          args.push(atom.config.get("linter-clang.clangDefaultObjCFlags"));
+          args.push(...atom.config.get("linter-clang.clangDefaultObjCFlags").split(/\s+/));
         }
 
         args.push(`-ferror-limit=${atom.config.get("linter-clang.clangErrorLimit")}`);


### PR DESCRIPTION
The default flags are fed into clang as one command line argument. For example, the default C++ flags are `-Wall -std=c++11`. This whole chunk is treated as one command line argument, rather than two. This is supported by the fact that clang is complaining: "warning: unknown warning option '-Wall -std=c++11' [-Wunknown-warning-option]".

This commit split the default flags into multiple strings. For example, `-Wall -std=c++11` becomes `-Wall` and `-std=c++11`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-clang/104)
<!-- Reviewable:end -->
