### PR TITLE
Added "Include Current File Directory" flag.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -41,6 +41,10 @@ export default {
     verboseDebug: {
       type: "boolean",
       default: false
+    },
+    includeCurrentFileDirectory: {
+      type: "boolean",
+      default: true
     }
   },
 
@@ -100,6 +104,14 @@ export default {
         atom.config.get("linter-clang.clangIncludePaths").forEach((path) =>
           args.push(`-I${path}`)
         );
+
+        if(atom.config.get("linter-clang.includeCurrentFileDirectory")){
+          var currentFileDirectory = activeEditor.getPath();
+          currentFileDirectory = currentFileDirectory.split('\\');
+          currentFileDirectory.pop();
+          currentFileDirectory = currentFileDirectory.join('\\');
+          args.push('-I'+currentFileDirectory);
+        }
 
         try {
           flags = clangFlags.getClangFlags(activeEditor.getPath());


### PR DESCRIPTION
Basically if this flag is set on, the current file directory will be included to the clang include paths.
For some reason clang can't find the header file from the same directory as source file.
For example, if i have a source file with:
`#include "something.h"`, 
where `something.h` is a header file from the same directory as source, I will get a error from linter:
`'something.h' file not found`.
That is not perfect solution, i guess, but it worked for me.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-clang/116)
<!-- Reviewable:end -->
