### PR TITLE
Support on the fly linting.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,7 @@ export default {
 
   provideLinter: () => {
     const helpers = require("atom-linter");
+    const path = require('path');
     const clangFlags = require("clang-flags");
     const regex = ".+?:(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)";
     return {
@@ -60,6 +61,7 @@ export default {
       lint: (activeEditor) => {
         const command = atom.config.get("linter-clang.execPath");
         const filePath = activeEditor.getPath();
+        const dir = path.dirname(filePath);
         const text = activeEditor.getText();
         const args = ["-fsyntax-only",
           "-fno-caret-diagnostics",
@@ -116,8 +118,8 @@ export default {
 
         // The file is added to the arguments last.
         args.push("-");
-        return helpers.exec(command, args, {stdin: text, stream: "stderr"}).then(output =>
-          helpers.parse(output, regex, {filePath : filePath})
+        return helpers.exec(command, args, {stdin: text, stream: "stderr", cwd: dir}).then(output =>
+          helpers.parse(output, regex, {filePath})
         );
       }
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,15 +51,16 @@ export default {
   provideLinter: () => {
     const helpers = require("atom-linter");
     const clangFlags = require("clang-flags");
-    const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)";
+    const regex = ".+?:(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)";
     return {
       name: "clang",
       grammarScopes: ["source.c", "source.cpp", "source.objc", "source.objcpp"],
       scope: "file",
-      lintOnFly: false,
+      lintOnFly: true,
       lint: (activeEditor) => {
         const command = atom.config.get("linter-clang.execPath");
-        const file = activeEditor.getPath();
+        const filePath = activeEditor.getPath();
+        const text = activeEditor.getText();
         const args = ["-fsyntax-only",
           "-fno-caret-diagnostics",
           "-fno-diagnostics-fixit-info",
@@ -114,9 +115,9 @@ export default {
         }
 
         // The file is added to the arguments last.
-        args.push(file);
-        return helpers.exec(command, args, {stream: "stderr"}).then(output =>
-          helpers.parse(output, regex)
+        args.push("-");
+        return helpers.exec(command, args, {stdin: text, stream: "stderr"}).then(output =>
+          helpers.parse(output, regex, {filePath : filePath})
         );
       }
     };


### PR DESCRIPTION
Enable on the fly linting by passing the window text into clang as stdin.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-clang/167)

<!-- Reviewable:end -->
