### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 # Project specific config
-os:
-  - linux
-  - osx
+language: generic
 
-env:
-  global:
-    - APM_TEST_PACKAGES=""
+matrix:
+  include:
+    - os: linux
+      env: ATOM_CHANNEL=stable
 
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
+    - os: linux
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      env: ATOM_CHANNEL=stable
 
 deploy:
   provider: apm
@@ -22,12 +23,19 @@ deploy:
     tags: true
 
 # Generic setup follows
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:
     on_success: never
     on_failure: change
+
+branches:
+  only:
+    - master
 
 git:
   depth: 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,20 @@
-version: "{build}"
-os: Windows Server 2012 R2
+### Project specific config ###
+environment:
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+### Generic setup follows ###
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
 branches:
   only:
     - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
 test: off
 deploy: off
-
-install:
-  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
-  - AtomSetup.exe /silent
-
-build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
-  - apm clean
-  - apm install
-  - apm test


### PR DESCRIPTION
AppVeyor changes:
* Move to using the latest `x64` platform, whatever that may be, instead of specifying an older OS version explicitely.
* Test on the Atom beta channel as well
* Use the build script to handle installing Atom and running the tests

Travis-CI changes:
* Only build on the `master` branch, this means PR's will only build a merge of the PR into `master` and not the additional "state of the PR iteself" build.
* Stop building the Beta channel on macOS to cut down on the super delayed macOS builds
* Fix how the script is executed