### PR TITLE
Enable ESLint

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-"use babel";
+'use babel';
 
 export default {
   config: {
@@ -7,108 +7,108 @@ export default {
     //  of clean code would cause a mess for our users. Because of this we
     //  override the titles the editor gives them in the settings pane.
     execPath: {
-      type: "string",
-      default: "clang"
+      type: 'string',
+      default: 'clang',
     },
     clangIncludePaths: {
-      type: "array",
-      default: ["."]
+      type: 'array',
+      default: ['.'],
     },
     clangSuppressWarnings: {
-      type: "boolean",
-      default: false
+      type: 'boolean',
+      default: false,
     },
     clangDefaultCFlags: {
-      type: "string",
-      default: "-Wall"
+      type: 'string',
+      default: '-Wall',
     },
     clangDefaultCppFlags: {
-      type: "string",
-      default: "-Wall -std=c++11"
+      type: 'string',
+      default: '-Wall -std=c++11',
     },
     clangDefaultObjCFlags: {
-      type: "string",
-      default: ""
+      type: 'string',
+      default: '',
     },
     clangDefaultObjCppFlags: {
-      type: "string",
-      default: ""
+      type: 'string',
+      default: '',
     },
     clangErrorLimit: {
-      type: "integer",
-      default: 0
+      type: 'integer',
+      default: 0,
     },
     verboseDebug: {
-      type: "boolean",
-      default: false
-    }
+      type: 'boolean',
+      default: false,
+    },
   },
 
   activate: () => {
-    require("atom-package-deps").install("linter-clang");
+    require('atom-package-deps').install('linter-clang');
   },
 
   provideLinter: () => {
-    const helpers = require("atom-linter");
-    const clangFlags = require("clang-flags");
-    const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)";
+    const helpers = require('atom-linter');
+    const clangFlags = require('clang-flags');
+    const regex = '(?<file>.+):(?<line>\\d+):(?<col>\\d+):({(?<lineStart>\\d+):(?<colStart>\\d+)-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)';
     return {
-      name: "clang",
-      grammarScopes: ["source.c", "source.cpp", "source.objc", "source.objcpp"],
-      scope: "file",
+      name: 'clang',
+      grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
+      scope: 'file',
       lintOnFly: false,
       lint: (activeEditor) => {
-        const command = atom.config.get("linter-clang.execPath");
+        const command = atom.config.get('linter-clang.execPath');
         const file = activeEditor.getPath();
-        const args = ["-fsyntax-only",
-          "-fno-caret-diagnostics",
-          "-fno-diagnostics-fixit-info",
-          "-fdiagnostics-print-source-range-info",
-          "-fexceptions"];
+        const args = ['-fsyntax-only',
+          '-fno-caret-diagnostics',
+          '-fno-diagnostics-fixit-info',
+          '-fdiagnostics-print-source-range-info',
+          '-fexceptions'];
 
         const grammar = activeEditor.getGrammar().name;
 
-        if(/^C\+\+/.test(grammar)) {
-          //const language = "c++";
-          args.push("-xc++");
-          args.push(...atom.config.get("linter-clang.clangDefaultCppFlags").split(/\s+/));
+        if (/^C\+\+/.test(grammar)) {
+          // const language = "c++";
+          args.push('-xc++');
+          args.push(...atom.config.get('linter-clang.clangDefaultCppFlags').split(/\s+/));
         }
-        if(grammar === "Objective-C++") {
-          //const language = "objective-c++";
-          args.push("-xobjective-c++");
-          args.push(...atom.config.get("linter-clang.clangDefaultObjCppFlags").split(/\s+/));
+        if (grammar === 'Objective-C++') {
+          // const language = "objective-c++";
+          args.push('-xobjective-c++');
+          args.push(...atom.config.get('linter-clang.clangDefaultObjCppFlags').split(/\s+/));
         }
-        if(grammar === "C") {
-          //const language = "c";
-          args.push("-xc");
-          args.push(...atom.config.get("linter-clang.clangDefaultCFlags").split(/\s+/));
+        if (grammar === 'C') {
+          // const language = "c";
+          args.push('-xc');
+          args.push(...atom.config.get('linter-clang.clangDefaultCFlags').split(/\s+/));
         }
-        if(grammar === "Objective-C") {
-          //const language = "objective-c";
-          args.push("-xobjective-c");
-          args.push(...atom.config.get("linter-clang.clangDefaultObjCFlags").split(/\s+/));
-        }
-
-        args.push(`-ferror-limit=${atom.config.get("linter-clang.clangErrorLimit")}`);
-        if(atom.config.get("linter-clang.clangSuppressWarnings")) {
-          args.push("-w");
-        }
-        if(atom.config.get("linter-clang.verboseDebug")) {
-          args.push("--verbose");
+        if (grammar === 'Objective-C') {
+          // const language = "objective-c";
+          args.push('-xobjective-c');
+          args.push(...atom.config.get('linter-clang.clangDefaultObjCFlags').split(/\s+/));
         }
 
-        atom.config.get("linter-clang.clangIncludePaths").forEach((path) =>
-          args.push(`-I${path}`)
+        args.push(`-ferror-limit=${atom.config.get('linter-clang.clangErrorLimit')}`);
+        if (atom.config.get('linter-clang.clangSuppressWarnings')) {
+          args.push('-w');
+        }
+        if (atom.config.get('linter-clang.verboseDebug')) {
+          args.push('--verbose');
+        }
+
+        atom.config.get('linter-clang.clangIncludePaths').forEach(path =>
+          args.push(`-I${path}`),
         );
 
         try {
-          flags = clangFlags.getClangFlags(activeEditor.getPath());
-          if(flags) {
-            args.push.apply(args, flags);
+          const flags = clangFlags.getClangFlags(activeEditor.getPath());
+          if (flags) {
+            args.push(...flags);
           }
-        }
-        catch (error) {
-          if(atom.config.get("linter-clang.verboseDebug")) {
+        } catch (error) {
+          if (atom.config.get('linter-clang.verboseDebug')) {
+            // eslint-disable-next-line no-console
             console.log(error);
           }
         }
@@ -116,13 +116,13 @@ export default {
         // The file is added to the arguments last.
         args.push(file);
         const execOpts = {
-          stream: "stderr",
+          stream: 'stderr',
           allowEmptyStderr: true,
         };
         return helpers.exec(command, args, execOpts).then(output =>
-          helpers.parse(output, regex)
+          helpers.parse(output, regex),
         );
-      }
+      },
     };
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "engines": {
     "atom": ">0.50.0"
   },
+  "scripts": {
+    "test": "apm test",
+    "lint": "eslint ."
+  },
   "providedServices": {
     "linter": {
       "versions": {
@@ -23,20 +27,33 @@
     "atom-package-deps": "^4.0.1",
     "clang-flags": "^0.2.2"
   },
+  "devDependencies": {
+    "eslint": "^3.13.0",
+    "eslint-config-airbnb-base": "^11.0.1",
+    "eslint-plugin-import": "^2.2.0"
+  },
   "packages-deps": [
     "linter"
   ],
   "eslintConfig": {
-    "env": {
-      "es6": true,
-      "browser": true,
-      "node": true
-    },
-    "ecmaFeatures": {
-      "modules": true
+    "extends": "airbnb-base",
+    "rules": {
+      "global-require": "off",
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "atom"
+          ]
+        }
+      ]
     },
     "globals": {
       "atom": true
+    },
+    "env": {
+      "browser": true,
+      "node": true
     }
   }
 }

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    atomtest: true,
+    jasmine: true
+  }
+};

--- a/spec/linter-clang-spec.js
+++ b/spec/linter-clang-spec.js
@@ -1,4 +1,4 @@
-"use babel";
+'use babel';
 
 import * as path from 'path';
 
@@ -6,69 +6,59 @@ const miPath = path.join(__dirname, 'files', 'missing_import');
 const validPath = path.join(__dirname, 'files', 'valid.c');
 
 describe('The Clang provider for AtomLinter', () => {
-  const lint = require('../lib/main').provideLinter().lint
+  const lint = require('../lib/main').provideLinter().lint;
 
   beforeEach(() => {
-    waitsForPromise(() => {
-      return atom.packages.activatePackage("linter-clang")
-    })
-  })
+    waitsForPromise(() => atom.packages.activatePackage('linter-clang'));
+  });
 
   it('finds nothing wrong with a valid file', () => {
     waitsForPromise(() =>
       atom.workspace.open(validPath).then(editor =>
         lint(editor).then((messages) => {
-          expect(messages.length).toBe(0)
-        })
-      )
-    )
-  })
+          expect(messages.length).toBe(0);
+        }),
+      ),
+    );
+  });
 
   it('finds a fatal error in "missing_import.c"', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(miPath + '.c').then(editor => {
-        return lint(editor).then(messages => {
-          expect(messages.length).toEqual(1)
-          expect(messages[0].type).toEqual("fatal error")
-          expect(messages[0].text).toEqual("'nothing.h' file not found")
-        })
-      })
-    })
-  })
+    waitsForPromise(() => atom.workspace.open(`${miPath}.c`).then(
+      editor => lint(editor).then((messages) => {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].type).toEqual('fatal error');
+        expect(messages[0].text).toEqual("'nothing.h' file not found");
+      }),
+    ));
+  });
 
   it('finds a fatal error in "missing_import.cpp"', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(miPath + '.cpp').then(editor => {
-        return lint(editor).then(messages => {
-          expect(messages.length).toEqual(1)
-          expect(messages[0].type).toEqual("fatal error")
-          expect(messages[0].text).toEqual("'nothing.h' file not found")
-        })
-      })
-    })
-  })
+    waitsForPromise(() => atom.workspace.open(`${miPath}.cpp`).then(
+      editor => lint(editor).then((messages) => {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].type).toEqual('fatal error');
+        expect(messages[0].text).toEqual("'nothing.h' file not found");
+      }),
+    ));
+  });
 
   it('finds a fatal error in "missing_import.m"', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(miPath + '.m').then(editor => {
-        return lint(editor).then(messages => {
-          expect(messages.length).toEqual(1)
-          expect(messages[0].type).toEqual("fatal error")
-          expect(messages[0].text).toEqual("'nothing.h' file not found")
-        })
-      })
-    })
-  })
+    waitsForPromise(() => atom.workspace.open(`${miPath}.m`).then(
+      editor => lint(editor).then((messages) => {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].type).toEqual('fatal error');
+        expect(messages[0].text).toEqual("'nothing.h' file not found");
+      }),
+    ));
+  });
 
   it('finds a fatal error in "missing_import.mm"', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(miPath + '.mm').then(editor => {
-        return lint(editor).then(messages => {
-          expect(messages.length).toEqual(1)
-          expect(messages[0].type).toEqual("fatal error")
-          expect(messages[0].text).toEqual("'nothing.h' file not found")
-        })
-      })
-    })
-  })
-})
+    waitsForPromise(() => atom.workspace.open(`${miPath}.mm`).then(
+      editor => lint(editor).then((messages) => {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].type).toEqual('fatal error');
+        expect(messages[0].text).toEqual("'nothing.h' file not found");
+      }),
+    ));
+  });
+});


### PR DESCRIPTION
Although there was a minimal ESLint configuration before, it had no rules enabled, and wasn't even checking the specs properly as it didn't have modules enabled in there. This fixes that by bringing in the same style guide used in almost all the other linter providers. This also lists ESLint as a dependency, so checking against this should work in the CI builds from now on.