### PR TITLE
Fix typo in package dependency specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0"
   },
-  "packages-deps": [
+  "package-deps": [
     "linter"
   ],
   "eslintConfig": {


### PR DESCRIPTION
This was causing an error about being unable to determine the package dependencies to be printed, and if this was the only provider a user has and they hand't installed Linter themselves they would be stuck with a completely unusable setup.

Fixes #183.