### PR TITLE
Remove macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
     - os: linux
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      env: ATOM_CHANNEL=stable
-
 deploy:
   provider: apm
   api_key:


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing. As there have been virtually no bugs found specifically on this platform it isn't worth the developer headaches of waiting forever for builds on it.
