### PR TITLE
Update to Linter v2

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import { CompositeDisposable } from 'atom';
 
 let helpers = null;
 let clangFlags = null;
+const regex = /(.+):(\d+):(\d+):(?:{(\d+):(\d+)-(\d+):(\d+)}.*:)? ([\w \\-]+): (.*)/g;
 
 export default {
   activate() {
@@ -57,11 +58,10 @@ export default {
   },
 
   provideLinter() {
-    const regex = '(?<file>.+):(?<line>\\d+):(?<col>\\d+):({(?<lineStart>\\d+):(?<colStart>\\d+)-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)';
     return {
       name: 'clang',
       scope: 'file',
-      lintOnFly: false,
+      lintsOnChange: false,
       grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
       lint: async (editor) => {
         if (helpers === null) {
@@ -146,7 +146,32 @@ export default {
           return null;
         }
 
-        return helpers.parse(output, regex);
+        const toReturn = [];
+        let match = regex.exec(output);
+
+        while (match !== null) {
+          let position;
+          if (match[4] !== undefined) {
+            const lineStart = Number.parseInt(match[4], 10) - 1;
+            const colStart = Number.parseInt(match[5], 10) - 1;
+            const lineEnd = Number.parseInt(match[6], 10) - 1;
+            const colEnd = Number.parseInt(match[7], 10) - 1;
+            position = [[lineStart, colStart], [lineEnd, colEnd]];
+          } else {
+            const line = Number.parseInt(match[2], 10) - 1;
+            const col = Number.parseInt(match[3], 10) - 1;
+            position = helpers.generateRange(editor, line, col);
+          }
+          const severity = /error/.test(match[8]) ? 'error' : 'warning';
+          toReturn.push({
+            severity,
+            location: { file: match[1], position },
+            excerpt: match[9],
+          });
+          match = regex.exec(output);
+        }
+
+        return toReturn;
       },
     };
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
+import { dirname } from 'path';
 
 let helpers = null;
 let clangFlags = null;
@@ -132,9 +133,15 @@ export default {
 
         args.push(filePath);
 
+        let [projectPath] = atom.project.relativizePath(filePath);
+        if (projectPath === null) {
+          projectPath = dirname(filePath);
+        }
+
         const execOpts = {
           stream: 'stderr',
           allowEmptyStderr: true,
+          cwd: projectPath,
         };
 
         const output = await helpers.exec(this.execPath, args, execOpts);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,10 @@
 'use babel';
 
+let helpers = null;
+let clangFlags = null;
+
 export default {
   config: {
-    // It should be noted that I, Kepler, hate these Config names. However these
-    //  are the names in use by many people. Changing them for the sake of clean
-    //  of clean code would cause a mess for our users. Because of this we
-    //  override the titles the editor gives them in the settings pane.
     execPath: {
       type: 'string',
       default: 'clang',
@@ -38,10 +37,6 @@ export default {
       type: 'integer',
       default: 0,
     },
-    verboseDebug: {
-      type: 'boolean',
-      default: false,
-    },
   },
 
   activate() {
@@ -49,8 +44,6 @@ export default {
   },
 
   provideLinter() {
-    const helpers = require('atom-linter');
-    const clangFlags = require('clang-flags');
     const regex = '(?<file>.+):(?<line>\\d+):(?<col>\\d+):({(?<lineStart>\\d+):(?<colStart>\\d+)-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)';
     return {
       name: 'clang',
@@ -58,33 +51,37 @@ export default {
       scope: 'file',
       lintOnFly: false,
       lint: (activeEditor) => {
+        if (helpers === null) {
+          helpers = require('atom-linter');
+        }
+        if (clangFlags === null) {
+          clangFlags = require('clang-flags');
+        }
         const command = atom.config.get('linter-clang.execPath');
-        const file = activeEditor.getPath();
-        const args = ['-fsyntax-only',
+        const filePath = activeEditor.getPath();
+        const args = [
+          '-fsyntax-only',
           '-fno-caret-diagnostics',
           '-fno-diagnostics-fixit-info',
           '-fdiagnostics-print-source-range-info',
-          '-fexceptions'];
+          '-fexceptions',
+        ];
 
         const grammar = activeEditor.getGrammar().name;
 
         if (/^C\+\+/.test(grammar)) {
-          // const language = "c++";
           args.push('-xc++');
           args.push(...atom.config.get('linter-clang.clangDefaultCppFlags').split(/\s+/));
         }
         if (grammar === 'Objective-C++') {
-          // const language = "objective-c++";
           args.push('-xobjective-c++');
           args.push(...atom.config.get('linter-clang.clangDefaultObjCppFlags').split(/\s+/));
         }
         if (grammar === 'C') {
-          // const language = "c";
           args.push('-xc');
           args.push(...atom.config.get('linter-clang.clangDefaultCFlags').split(/\s+/));
         }
         if (grammar === 'Objective-C') {
-          // const language = "objective-c";
           args.push('-xobjective-c');
           args.push(...atom.config.get('linter-clang.clangDefaultObjCFlags').split(/\s+/));
         }
@@ -93,7 +90,7 @@ export default {
         if (atom.config.get('linter-clang.clangSuppressWarnings')) {
           args.push('-w');
         }
-        if (atom.config.get('linter-clang.verboseDebug')) {
+        if (atom.inDevMode()) {
           args.push('--verbose');
         }
 
@@ -102,23 +99,23 @@ export default {
         );
 
         try {
-          const flags = clangFlags.getClangFlags(activeEditor.getPath());
+          const flags = clangFlags.getClangFlags(filePath);
           if (flags) {
             args.push(...flags);
           }
         } catch (error) {
-          if (atom.config.get('linter-clang.verboseDebug')) {
+          if (atom.inDevMode()) {
             // eslint-disable-next-line no-console
             console.log(error);
           }
         }
+        args.push(filePath);
 
-        // The file is added to the arguments last.
-        args.push(file);
         const execOpts = {
           stream: 'stderr',
           allowEmptyStderr: true,
         };
+
         return helpers.exec(command, args, execOpts).then(output =>
           helpers.parse(output, regex),
         );

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,10 +11,21 @@ const regex = /(.+):(\d+):(\d+):(?:{(\d+):(\d+)-(\d+):(\d+)}.*:)? ([\w \\-]+): (
 export default {
   activate() {
     require('atom-package-deps').install('linter-clang');
+
+    // FIXME: Remove backwards compatibility in a future minor version
+    const oldPath = atom.config.get('linter-clang.execPath');
+    if (oldPath !== undefined) {
+      atom.config.unset('linter-clang.execPath');
+      if (oldPath !== 'clang') {
+        // If the old config wasn't set to the default migrate it over
+        atom.config.set('linter-pylint.executablePath', oldPath);
+      }
+    }
+
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
-      atom.config.observe('linter-clang.execPath', (value) => {
-        this.execPath = value;
+      atom.config.observe('linter-clang.executablePath', (value) => {
+        this.executablePath = value;
       }),
     );
     this.subscriptions.add(
@@ -150,7 +161,7 @@ export default {
           cwd: projectPath,
         };
 
-        const output = await helpers.exec(this.execPath, args, execOpts);
+        const output = await helpers.exec(this.executablePath, args, execOpts);
 
         if (editor.getText() !== fileText) {
           // Editor contents have changed, tell Linter not to update results

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,7 +63,7 @@ export default {
       scope: 'file',
       lintOnFly: false,
       grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
-      lint: (activeEditor) => {
+      lint: (editor) => {
         if (helpers === null) {
           helpers = require('atom-linter');
         }
@@ -71,38 +71,44 @@ export default {
           clangFlags = require('clang-flags');
         }
 
-        const filePath = activeEditor.getPath();
+        const filePath = editor.getPath();
+
         const args = [
           '-fsyntax-only',
           '-fno-caret-diagnostics',
           '-fno-diagnostics-fixit-info',
           '-fdiagnostics-print-source-range-info',
           '-fexceptions',
+          `-ferror-limit=${this.clangErrorLimit}`,
         ];
 
-        const grammar = activeEditor.getGrammar().name;
+        const grammar = editor.getGrammar().name;
 
-        if (/^C\+\+/.test(grammar)) {
-          args.push('-xc++');
-          args.push(...this.clangDefaultCppFlags.split(/\s+/));
-        }
-        if (grammar === 'Objective-C++') {
-          args.push('-xobjective-c++');
-          args.push(...this.clangDefaultObjCppFlags.split(/\s+/));
-        }
-        if (grammar === 'C') {
-          args.push('-xc');
-          args.push(...this.clangDefaultCFlags.split(/\s+/));
-        }
-        if (grammar === 'Objective-C') {
-          args.push('-xobjective-c');
-          args.push(...this.clangDefaultObjCFlags.split(/\s+/));
+        switch (grammar) {
+          case 'Objective-C++':
+            args.push('-xobjective-c++');
+            args.push(...this.clangDefaultObjCppFlags.split(/\s+/));
+            break;
+          case 'C':
+            args.push('-xc');
+            args.push(...this.clangDefaultCFlags.split(/\s+/));
+            break;
+          case 'Objective-C':
+            args.push('-xobjective-c');
+            args.push(...this.clangDefaultObjCFlags.split(/\s+/));
+            break;
+          default:
+          case 'C++':
+          case 'C++14':
+            args.push('-xc++');
+            args.push(...this.clangDefaultCppFlags.split(/\s+/));
+            break;
         }
 
-        args.push(`-ferror-limit=${this.clangErrorLimit}`);
         if (this.clangSuppressWarnings) {
           args.push('-w');
         }
+
         if (atom.inDevMode()) {
           args.push('--verbose');
         }
@@ -122,6 +128,7 @@ export default {
             console.log(error);
           }
         }
+
         args.push(filePath);
 
         const execOpts = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
-import { dirname } from 'path';
+import { dirname, extname } from 'path';
 
 let helpers = null;
 let clangFlags = null;
@@ -73,6 +73,7 @@ export default {
         }
 
         const filePath = editor.getPath();
+        const fileExt = extname(filePath);
         const fileText = editor.getText();
 
         const args = [
@@ -87,6 +88,10 @@ export default {
         const grammar = editor.getGrammar().name;
 
         switch (grammar) {
+          case 'Objective-C':
+            args.push('-xobjective-c');
+            args.push(...this.clangDefaultObjCFlags.split(/\s+/));
+            break;
           case 'Objective-C++':
             args.push('-xobjective-c++');
             args.push(...this.clangDefaultObjCppFlags.split(/\s+/));
@@ -95,16 +100,17 @@ export default {
             args.push('-xc');
             args.push(...this.clangDefaultCFlags.split(/\s+/));
             break;
-          case 'Objective-C':
-            args.push('-xobjective-c');
-            args.push(...this.clangDefaultObjCFlags.split(/\s+/));
-            break;
           default:
           case 'C++':
           case 'C++14':
             args.push('-xc++');
             args.push(...this.clangDefaultCppFlags.split(/\s+/));
             break;
+        }
+
+        if (fileExt === '.hpp' || fileExt === '.hh' || fileExt === '.h') {
+          // Don't warn about #pragma once when linting header files
+          args.push('-Wno-pragma-once-outside-header');
         }
 
         if (this.clangSuppressWarnings) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,20 +1,68 @@
 'use babel';
 
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
+import { CompositeDisposable } from 'atom';
+
 let helpers = null;
 let clangFlags = null;
 
 export default {
   activate() {
     require('atom-package-deps').install('linter-clang');
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.execPath', (value) => {
+        this.execPath = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangIncludePaths', (value) => {
+        this.clangIncludePaths = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangSuppressWarnings', (value) => {
+        this.clangSuppressWarnings = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangDefaultCFlags', (value) => {
+        this.clangDefaultCFlags = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangDefaultCppFlags', (value) => {
+        this.clangDefaultCppFlags = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangDefaultObjCFlags', (value) => {
+        this.clangDefaultObjCFlags = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangDefaultObjCppFlags', (value) => {
+        this.clangDefaultObjCppFlags = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-clang.clangErrorLimit', (value) => {
+        this.clangErrorLimit = value;
+      }),
+    );
+  },
+
+  deactivate() {
+    this.subscriptions.dispose();
   },
 
   provideLinter() {
     const regex = '(?<file>.+):(?<line>\\d+):(?<col>\\d+):({(?<lineStart>\\d+):(?<colStart>\\d+)-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)';
     return {
       name: 'clang',
-      grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
       scope: 'file',
       lintOnFly: false,
+      grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
       lint: (activeEditor) => {
         if (helpers === null) {
           helpers = require('atom-linter');
@@ -22,7 +70,7 @@ export default {
         if (clangFlags === null) {
           clangFlags = require('clang-flags');
         }
-        const command = atom.config.get('linter-clang.execPath');
+
         const filePath = activeEditor.getPath();
         const args = [
           '-fsyntax-only',
@@ -36,30 +84,30 @@ export default {
 
         if (/^C\+\+/.test(grammar)) {
           args.push('-xc++');
-          args.push(...atom.config.get('linter-clang.clangDefaultCppFlags').split(/\s+/));
+          args.push(...this.clangDefaultCppFlags.split(/\s+/));
         }
         if (grammar === 'Objective-C++') {
           args.push('-xobjective-c++');
-          args.push(...atom.config.get('linter-clang.clangDefaultObjCppFlags').split(/\s+/));
+          args.push(...this.clangDefaultObjCppFlags.split(/\s+/));
         }
         if (grammar === 'C') {
           args.push('-xc');
-          args.push(...atom.config.get('linter-clang.clangDefaultCFlags').split(/\s+/));
+          args.push(...this.clangDefaultCFlags.split(/\s+/));
         }
         if (grammar === 'Objective-C') {
           args.push('-xobjective-c');
-          args.push(...atom.config.get('linter-clang.clangDefaultObjCFlags').split(/\s+/));
+          args.push(...this.clangDefaultObjCFlags.split(/\s+/));
         }
 
-        args.push(`-ferror-limit=${atom.config.get('linter-clang.clangErrorLimit')}`);
-        if (atom.config.get('linter-clang.clangSuppressWarnings')) {
+        args.push(`-ferror-limit=${this.clangErrorLimit}`);
+        if (this.clangSuppressWarnings) {
           args.push('-w');
         }
         if (atom.inDevMode()) {
           args.push('--verbose');
         }
 
-        atom.config.get('linter-clang.clangIncludePaths').forEach(path =>
+        this.clangIncludePaths.forEach(path =>
           args.push(`-I${path}`),
         );
 
@@ -81,7 +129,7 @@ export default {
           allowEmptyStderr: true,
         };
 
-        return helpers.exec(command, args, execOpts).then(output =>
+        return helpers.exec(this.execPath, args, execOpts).then(output =>
           helpers.parse(output, regex),
         );
       },

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,41 +4,6 @@ let helpers = null;
 let clangFlags = null;
 
 export default {
-  config: {
-    execPath: {
-      type: 'string',
-      default: 'clang',
-    },
-    clangIncludePaths: {
-      type: 'array',
-      default: ['.'],
-    },
-    clangSuppressWarnings: {
-      type: 'boolean',
-      default: false,
-    },
-    clangDefaultCFlags: {
-      type: 'string',
-      default: '-Wall',
-    },
-    clangDefaultCppFlags: {
-      type: 'string',
-      default: '-Wall -std=c++11',
-    },
-    clangDefaultObjCFlags: {
-      type: 'string',
-      default: '',
-    },
-    clangDefaultObjCppFlags: {
-      type: 'string',
-      default: '',
-    },
-    clangErrorLimit: {
-      type: 'integer',
-      default: 0,
-    },
-  },
-
   activate() {
     require('atom-package-deps').install('linter-clang');
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,7 +63,7 @@ export default {
       scope: 'file',
       lintOnFly: false,
       grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
-      lint: (editor) => {
+      lint: async (editor) => {
         if (helpers === null) {
           helpers = require('atom-linter');
         }
@@ -72,6 +72,7 @@ export default {
         }
 
         const filePath = editor.getPath();
+        const fileText = editor.getText();
 
         const args = [
           '-fsyntax-only',
@@ -136,9 +137,16 @@ export default {
           allowEmptyStderr: true,
         };
 
-        return helpers.exec(this.execPath, args, execOpts).then(output =>
-          helpers.parse(output, regex),
-        );
+        const output = await helpers.exec(this.execPath, args, execOpts);
+
+        if (editor.getText() !== fileText) {
+          // Editor contents have changed, tell Linter not to update results
+          // eslint-disable-next-line no-console
+          console.warn('linter-clang: Editor contents changed, not updating results');
+          return null;
+        }
+
+        return helpers.parse(output, regex);
       },
     };
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,43 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.4.0 <2.0.0"
+  },
+  "configSchema": {
+    "execPath": {
+      "type": "string",
+      "default": "clang"
+    },
+    "clangIncludePaths": {
+      "type": "array",
+      "default": [
+        "."
+      ]
+    },
+    "clangSuppressWarnings": {
+      "type": "boolean",
+      "default": false
+    },
+    "clangDefaultCFlags": {
+      "type": "string",
+      "default": "-Wall"
+    },
+    "clangDefaultCppFlags": {
+      "type": "string",
+      "default": "-Wall -std=c++11"
+    },
+    "clangDefaultObjCFlags": {
+      "type": "string",
+      "default": ""
+    },
+    "clangDefaultObjCppFlags": {
+      "type": "string",
+      "default": ""
+    },
+    "clangErrorLimit": {
+      "type": "integer",
+      "default": 0
+    }
   },
   "scripts": {
     "test": "apm test",

--- a/package.json
+++ b/package.json
@@ -54,13 +54,13 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },
   "dependencies": {
     "atom-linter": "^9.0.0",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.5.0",
     "clang-flags": "^0.2.2"
   },
   "devDependencies": {
@@ -70,7 +70,7 @@
     "jasmine-fix": "^1.0.1"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom": ">=1.4.0 <2.0.0"
   },
   "configSchema": {
-    "execPath": {
+    "executablePath": {
       "type": "string",
       "default": "clang"
     },

--- a/spec/files/pragma/pragma_once.c
+++ b/spec/files/pragma/pragma_once.c
@@ -1,0 +1,3 @@
+#pragma once
+
+int main() {}

--- a/spec/files/pragma/pragma_once.cpp
+++ b/spec/files/pragma/pragma_once.cpp
@@ -1,0 +1,3 @@
+#pragma once
+
+int main() {}

--- a/spec/files/pragma/pragma_once.h
+++ b/spec/files/pragma/pragma_once.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int main() {}

--- a/spec/files/pragma/pragma_once.hpp
+++ b/spec/files/pragma/pragma_once.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+int main() {}

--- a/spec/linter-clang-spec.js
+++ b/spec/linter-clang-spec.js
@@ -29,7 +29,7 @@ describe('The Clang provider for AtomLinter', () => {
       expect(messages[0].severity).toBe('error');
       expect(messages[0].excerpt).toBe("'nothing.h' file not found");
       expect(messages[0].location.file).toBe(`${miPath}.c`);
-      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 20]]);
     });
 
     it('finds a fatal error in "missing_import.cpp"', async () => {
@@ -39,7 +39,7 @@ describe('The Clang provider for AtomLinter', () => {
       expect(messages[0].severity).toBe('error');
       expect(messages[0].excerpt).toBe("'nothing.h' file not found");
       expect(messages[0].location.file).toBe(`${miPath}.cpp`);
-      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 20]]);
     });
 
     it('finds a fatal error in "missing_import.m"', async () => {
@@ -49,7 +49,7 @@ describe('The Clang provider for AtomLinter', () => {
       expect(messages[0].severity).toBe('error');
       expect(messages[0].excerpt).toBe("'nothing.h' file not found");
       expect(messages[0].location.file).toBe(`${miPath}.m`);
-      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 20]]);
     });
 
     it('finds a fatal error in "missing_import.mm"', async () => {
@@ -59,7 +59,7 @@ describe('The Clang provider for AtomLinter', () => {
       expect(messages[0].severity).toBe('error');
       expect(messages[0].excerpt).toBe("'nothing.h' file not found");
       expect(messages[0].location.file).toBe(`${miPath}.mm`);
-      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 20]]);
     });
   });
 });

--- a/spec/linter-clang-spec.js
+++ b/spec/linter-clang-spec.js
@@ -26,32 +26,40 @@ describe('The Clang provider for AtomLinter', () => {
       const editor = await atom.workspace.open(`${miPath}.c`);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
-      expect(messages[0].type).toBe('fatal error');
-      expect(messages[0].text).toBe("'nothing.h' file not found");
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].excerpt).toBe("'nothing.h' file not found");
+      expect(messages[0].location.file).toBe(`${miPath}.c`);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
     });
 
     it('finds a fatal error in "missing_import.cpp"', async () => {
       const editor = await atom.workspace.open(`${miPath}.cpp`);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
-      expect(messages[0].type).toEqual('fatal error');
-      expect(messages[0].text).toEqual("'nothing.h' file not found");
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].excerpt).toBe("'nothing.h' file not found");
+      expect(messages[0].location.file).toBe(`${miPath}.cpp`);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
     });
 
     it('finds a fatal error in "missing_import.m"', async () => {
       const editor = await atom.workspace.open(`${miPath}.m`);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
-      expect(messages[0].type).toEqual('fatal error');
-      expect(messages[0].text).toEqual("'nothing.h' file not found");
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].excerpt).toBe("'nothing.h' file not found");
+      expect(messages[0].location.file).toBe(`${miPath}.m`);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
     });
 
     it('finds a fatal error in "missing_import.mm"', async () => {
       const editor = await atom.workspace.open(`${miPath}.mm`);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
-      expect(messages[0].type).toEqual('fatal error');
-      expect(messages[0].text).toEqual("'nothing.h' file not found");
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].excerpt).toBe("'nothing.h' file not found");
+      expect(messages[0].location.file).toBe(`${miPath}.mm`);
+      expect(messages[0].location.position).toEqual([[1, 9], [1, 17]]);
     });
   });
 });

--- a/spec/linter-clang-spec.js
+++ b/spec/linter-clang-spec.js
@@ -7,6 +7,7 @@ import { join } from 'path';
 const lint = require('../lib/main').provideLinter().lint;
 
 const miPath = join(__dirname, 'files', 'missing_import');
+const poPath = join(__dirname, 'files', 'pragma', 'pragma_once');
 const validPath = join(__dirname, 'files', 'valid.c');
 
 describe('The Clang provider for AtomLinter', () => {
@@ -60,6 +61,40 @@ describe('The Clang provider for AtomLinter', () => {
       expect(messages[0].excerpt).toBe("'nothing.h' file not found");
       expect(messages[0].location.file).toBe(`${miPath}.mm`);
       expect(messages[0].location.position).toEqual([[1, 9], [1, 20]]);
+    });
+  });
+
+  describe('handles pragma once properly', () => {
+    it('finds a pragma once warning in pragma_once.c', async () => {
+      const editor = await atom.workspace.open(`${poPath}.c`);
+      const messages = await lint(editor);
+      expect(messages.length).toEqual(1);
+      expect(messages[0].severity).toEqual('warning');
+      expect(messages[0].excerpt).toEqual('#pragma once in main file [-Wpragma-once-outside-header]');
+      expect(messages[0].location.file).toBe(`${poPath}.c`);
+      expect(messages[0].location.position).toEqual([[0, 8], [0, 12]]);
+    });
+
+    it('finds a pragma once warning in pragma_once.cpp', async () => {
+      const editor = await atom.workspace.open(`${poPath}.cpp`);
+      const messages = await lint(editor);
+      expect(messages.length).toEqual(1);
+      expect(messages[0].severity).toEqual('warning');
+      expect(messages[0].excerpt).toEqual('#pragma once in main file [-Wpragma-once-outside-header]');
+      expect(messages[0].location.file).toBe(`${poPath}.cpp`);
+      expect(messages[0].location.position).toEqual([[0, 8], [0, 12]]);
+    });
+
+    it("doesn't find a pragma once warning in pragma_once.h", async () => {
+      const editor = await atom.workspace.open(`${poPath}.h`);
+      const messages = await lint(editor);
+      expect(messages.length).toEqual(0);
+    });
+
+    it("doesn't find a pragma once warning in pragma_once.hpp", async () => {
+      const editor = await atom.workspace.open(`${poPath}.hpp`);
+      const messages = await lint(editor);
+      expect(messages.length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
Update the the Linter v2 API and fix many bugs including:

* Use `generateRange` to create a range highlighting an entire word when `clang` only provides a single point (#147, #190)
* Filter out `#pragma once` messages in header files, but _not_ other files (#88)
* Run `clang` from the project directory, or from the directory of the file if it wasn't opened as a project (#102)
* Rename `execPath` to `executablePath`.

Examples of the range highlighting:
Before:
![image](https://cloud.githubusercontent.com/assets/427137/24474591/f19e8502-1481-11e7-903b-a3d5b9635373.png)

After:
![image](https://cloud.githubusercontent.com/assets/427137/24474631/10f55f98-1482-11e7-908b-7f45e161147e.png)


Fixes #190.
Fixes #147.
Closes #120.
Fixes #102.
Fixes #88.