### PR TITLE
Enable linting on change

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -73,7 +73,7 @@ export default {
     return {
       name: 'clang',
       scope: 'file',
-      lintsOnChange: false,
+      lintsOnChange: true,
       grammarScopes: ['source.c', 'source.cpp', 'source.objc', 'source.objcpp'],
       lint: async (editor) => {
         if (helpers === null) {
@@ -84,7 +84,13 @@ export default {
         }
 
         const filePath = editor.getPath();
+        if (filePath === undefined) {
+          // The editor has no path, meaning it hasn't been saved. Although
+          // clang could give us results for this, Linter needs a path
+          return [];
+        }
         const fileExt = extname(filePath);
+        const fileDir = dirname(filePath);
         const fileText = editor.getText();
 
         const args = [
@@ -96,6 +102,7 @@ export default {
           `-ferror-limit=${this.clangErrorLimit}`,
         ];
 
+        // Non-Public API!
         const grammar = editor.getGrammar().name;
 
         switch (grammar) {
@@ -148,17 +155,13 @@ export default {
           }
         }
 
-        args.push(filePath);
-
-        let [projectPath] = atom.project.relativizePath(filePath);
-        if (projectPath === null) {
-          projectPath = dirname(filePath);
-        }
+        args.push('-');
 
         const execOpts = {
+          stdin: fileText,
           stream: 'stderr',
           allowEmptyStderr: true,
-          cwd: projectPath,
+          cwd: fileDir,
         };
 
         const output = await helpers.exec(this.executablePath, args, execOpts);
@@ -187,9 +190,11 @@ export default {
             position = helpers.generateRange(editor, line, col);
           }
           const severity = /error/.test(match[8]) ? 'error' : 'warning';
+          // Handle paths other than the file being linted still
+          const file = match[1] === '<stdin>' ? filePath : match[1];
           toReturn.push({
             severity,
-            location: { file: match[1], position },
+            location: { file, position },
             excerpt: match[9],
           });
           match = regex.exec(output);


### PR DESCRIPTION
It looks like we might be safe to move to using `stdin` input to `clang` by changing the CWD to that of the file instead of the current project/file setting. Since that was only a guess and hasn't went live, we might as well start with this to see how things work out.

Closes #167.