### PR TITLE
If using .clang-complete disable for modified files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -214,10 +214,12 @@ export default {
           args.push(`-I${path}`),
         );
 
+        let usingClangComplete = false;
         try {
           const flags = clangFlags.getClangFlags(filePath);
-          if (flags) {
+          if (flags.length > 0) {
             args.push(...flags);
+            usingClangComplete = true;
           }
         } catch (error) {
           if (atom.inDevMode()) {
@@ -226,14 +228,24 @@ export default {
           }
         }
 
-        args.push('-');
+        if (editor.isModified() && usingClangComplete) {
+          // If the user has a .clang-complete file we can't lint current
+          // TextEditor contents, return null so nothing gets modified
+          return null;
+        }
 
         const execOpts = {
-          stdin: fileText,
           stream: 'stderr',
           allowEmptyStderr: true,
-          cwd: fileDir,
         };
+
+        if (usingClangComplete) {
+          args.push(filePath);
+        } else {
+          args.push('-');
+          execOpts.stdin = fileText;
+          execOpts.cwd = fileDir;
+        }
 
         const output = await helpers.exec(this.executablePath, args, execOpts);
 


### PR DESCRIPTION
If there is a .clang-complete file it sends a flag to clang setting the working directory to that of the .clang-complete file, breaking relative includes for a file sent in over stdin. If a .clang-complete is in use disable linting modified files.

Fixes #196.