### PR TITLE
Stop using -fdiagnostics-absolute-paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
-import { dirname, extname } from 'path';
+import { dirname, extname, resolve, isAbsolute } from 'path';
 
 let helpers = null;
 let clangFlags = null;
@@ -162,11 +162,11 @@ export default {
         const fileExt = extname(filePath);
         const fileDir = dirname(filePath);
         const fileText = editor.getText();
+        let basePath;
 
         const args = [
           '-fsyntax-only',
           '-fno-color-diagnostics',
-          '-fdiagnostics-absolute-paths',
           '-fdiagnostics-parseable-fixits',
           '-fdiagnostics-print-source-range-info',
           '-fexceptions',
@@ -217,10 +217,14 @@ export default {
         let usingClangComplete = false;
         try {
           const flags = clangFlags.getClangFlags(filePath);
-          if (flags.length > 0) {
-            args.push(...flags);
+          flags.forEach((flag) => {
+            args.push(flag);
             usingClangComplete = true;
-          }
+            const workingDir = /-working-directory=(.+)/.exec(flag);
+            if (workingDir !== null) {
+              basePath = workingDir[1];
+            }
+          });
         } catch (error) {
           if (atom.inDevMode()) {
             // eslint-disable-next-line no-console
@@ -245,6 +249,7 @@ export default {
           args.push('-');
           execOpts.stdin = fileText;
           execOpts.cwd = fileDir;
+          basePath = fileDir;
         }
 
         const output = await helpers.exec(this.executablePath, args, execOpts);
@@ -260,7 +265,14 @@ export default {
         while (match !== null) {
           const isCurrentFile = match[1] === '<stdin>';
           // If the "file" is stdin, override to the current editor's path
-          const file = isCurrentFile ? filePath : match[1];
+          let file;
+          if (isCurrentFile) {
+            file = filePath;
+          } else if (isAbsolute(match[1])) {
+            file = match[1];
+          } else {
+            file = resolve(basePath, match[1]);
+          }
           let position;
           if (match[4]) {
             // Clang gave us a range, use that
@@ -270,7 +282,7 @@ export default {
             const line = Number.parseInt(match[2], 10) - 1;
             const col = Number.parseInt(match[3], 10) - 1;
             if (!isCurrentFile) {
-              const fileEditor = findTextEditor(match[1]);
+              const fileEditor = findTextEditor(file);
               if (fileEditor !== false) {
                 // Found an open editor for the file
                 position = helpers.generateRange(fileEditor, line, col);


### PR DESCRIPTION
It seems that the `-fdiagnostics-absolute-paths` flag was only introduced in LLVM v4.0.0, as such the usage of this flag was breaking this package for all users on an older version of LLVM. Move to parsing the relative paths coming from `clang` based on the working directory, attempting to handle relative directory overrides coming from `clang-complete` as well.

Fixes #199.