### PR TITLE
Use -Wno-unused-const-variable for header files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -185,6 +185,8 @@ export default {
         if (fileExt === '.hpp' || fileExt === '.hh' || fileExt === '.h') {
           // Don't warn about #pragma once when linting header files
           args.push('-Wno-pragma-once-outside-header');
+          // Don't warn about unused-const-variable when linting header files
+          args.push('-Wno-unused-const-variable');
         }
 
         if (this.clangSuppressWarnings) {


### PR DESCRIPTION
Don't warn about unused const variables when linting header files.

Avoids warnings like this:
![screen shot 2018-05-11 at 10 46 40 am](https://user-images.githubusercontent.com/3719564/39933378-cb0f8280-5510-11e8-96cb-03458ba4ee58.png)
