### PR TITLE
Fix CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,97 +1,113 @@
 version: 2
 
 defaults: &defaults
- working_directory: /tmp/project
- docker:
-   - image: walberla/buildenv-ubuntu-clang:4.0
-     environment:
-       CIRCLE_BUILD_IMAGE: ubuntu
-       ATOM_CHANNEL: stable
-       DISPLAY: :99
+  working_directory: /tmp/project
+  docker:
+    - image: arcanemagus/atom-docker-ci:stable
+  steps:
+    # Restore project state
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Install Clang
+        command: |
+          sudo apt-get update && \
+          sudo apt-get install --assume-yes --quiet --no-install-suggests \
+            --no-install-recommends clang
+    - run:
+        name: Create VFB for Atom to run in
+        command: /usr/local/bin/xvfb_start
+    - run:
+        name: Atom version
+        command: ${ATOM_SCRIPT_PATH} --version
+    - run:
+        name: APM version
+        command: ${APM_SCRIPT_PATH} --version
+    - run:
+        name: Package APM package dependencies
+        command: |
+          if [ -n "${APM_TEST_PACKAGES}" ]; then
+            for pack in ${APM_TEST_PACKAGES}; do
+            ${APM_SCRIPT_PATH} install "${pack}"
+            done
+          fi;
+    - run:
+        name: Package dependencies
+        command: ${APM_SCRIPT_PATH} install
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
+    - run:
+        name: Package specs
+        command: ${ATOM_SCRIPT_PATH} --test spec
+    # Cache node_modules
+    - save_cache:
+        paths:
+          - node_modules
+        key: v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
 
 jobs:
   checkout_code:
     <<: *defaults
+    docker:
+      - image: circleci/node:latest
     steps:
       - checkout
-      - run:
-          name: Download Atom test script
-          command: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-      - run:
-          name: Make Atom script executable
-          command: chmod u+x build-package.sh
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v2-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v2-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v3-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v3-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp
           paths:
             - project
-
+  lint:
+    <<: *defaults
+    docker:
+      - image: circleci/node:latest
+    steps:
+      # Restore project state
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Node.js Version
+          command: node --version
+      - run:
+          name: NPM Version
+          command: npm --version
+      - run:
+          name: Install any remaining dependencies
+          command: npm install
+      - run:
+          name: Lint code
+          command: npm run lint
   stable:
     <<: *defaults
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Atom test
-          command: ./build-package.sh
-      # Cache node_modules
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
-
   beta:
     <<: *defaults
-    environment:
-      ATOM_CHANNEL: beta
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Atom test
-          command: ./build-package.sh
+    docker:
+      - image: arcanemagus/atom-docker-ci:beta
 
 workflows:
   version: 2
   test_package:
     jobs:
       - checkout_code
+      - lint:
+          requires:
+            - checkout_code
       - stable:
           requires:
-            - checkout_code
+            - lint
       - beta:
           requires:
-            - checkout_code
+            - lint


### PR DESCRIPTION
It seems that the `walberla/buildenv-ubuntu-clang:4.0` image in use before is no longer working. Move to the `arcanemagus/atom-docker-ci` based images that pre-install Atom, but require Clang to be installed as 
they should be a more stable base.